### PR TITLE
chore(pnpm): add minimumReleaseAge to pnpm-workspace.yaml

### DIFF
--- a/iot-app/front/pnpm-workspace.yaml
+++ b/iot-app/front/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - '.'
+
+# 悪意のあるリリースは1週間以内に発見され、レジストリから削除される為
+# config = 7 day x 24h x 60 min
+minimumReleaseAge: 10080


### PR DESCRIPTION
## 概要
- `iot-app/front/pnpm-workspace.yaml` を追加し、`minimumReleaseAge: 10080`（7日間＝分単位）を設定する。
- 悪意のあるリリースは公開からおおむね1週間以内に検知・レジストリから削除されることが多い、という前提に基づく。

## 変更ファイル
- `iot-app/front/pnpm-workspace.yaml`

## 動作確認
- `cd iot-app/front && pnpm install` が成功することを確認。

Closes #131