### PR TITLE
build: TypeScript 6対応とAngular依存更新およびpnpm供給網ポリシー再有効化

### DIFF
--- a/iot-app/front/pnpm-workspace.yaml
+++ b/iot-app/front/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ packages:
 
 # 悪意のあるリリースは1週間以内に発見され、レジストリから削除される為
 # config = 7 day x 24h x 60 min
-# minimumReleaseAge: 10080
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
- TypeScript を `6.0.3` に更新し、`tsconfig.json` に `ignoreDeprecations: \"6.0\"` を追加して `baseUrl` 非推奨エラー（TS5101）を解消
- Angular フレームワーク/CLI 関連依存と `zone.js` をパッチバージョンへ更新し、`pnpm-lock.yaml` を同期
- `pnpm-workspace.yaml` の `minimumReleaseAge` を再有効化し、依存導入時の供給網リスク対策を復元

## Test plan
- [x] `npm run build` が成功すること
- [ ] `npm test` が成功すること
- [ ] 主要画面の起動・遷移を手動確認すること

Made with [Cursor](https://cursor.com)